### PR TITLE
Map label-to-qubit and label-to-index in separate functions

### DIFF
--- a/pennylane_rigetti/qc.py
+++ b/pennylane_rigetti/qc.py
@@ -183,8 +183,6 @@ class QuantumComputerDevice(RigettiDevice, ABC):
 
         return timeout_args
 
-    def define_wire_map(self, wires):
-        return OrderedDict(zip(range(len(self._qubits)), self._qubits))
 
     def apply(self, operations, **kwargs):
         """Applies the given quantum operations."""
@@ -220,7 +218,7 @@ class QuantumComputerDevice(RigettiDevice, ABC):
         # Apply the circuit operations
         for i, operation in enumerate(operations):
             # map the operation wires to the physical device qubits
-            device_wires = self.map_wires(operation.wires)
+            backend_wires = self.map_wires_to_backend(operation.wires)
 
             if i > 0 and operation.name in (
                 "QubitStateVector",
@@ -255,7 +253,7 @@ class QuantumComputerDevice(RigettiDevice, ABC):
                 else:
                     par.append(param)
 
-            prog += self._operation_map[operation.name](*par, *device_wires.labels)
+            prog += self._operation_map[operation.name](*par, *backend_wires.labels)
 
         return prog
 


### PR DESCRIPTION
Currently the PL-Rigetti plugin uses the `map_wires` method to map the user-defined wire labels to the backend qubit labels. However, this method is overwriting a method from the PennyLane device base class that is used in PennyLane's post-processing of the returned samples.

In order to allow user-defined wire labels on the device, we need to be able to map these two concepts (wire labels to sample index and wire label to qubit number) separately. 

This PR changes the methods that build the PyQuil program to use a new `map_wires_to_backend` method, so that the needed mapping can be included there without modifying the label-to-index mapping used by PL's post-processing. This is implemented on the base `RigettiDevice`.